### PR TITLE
VLC client poll and emit song change events

### DIFF
--- a/lib/vlc.js
+++ b/lib/vlc.js
@@ -1,17 +1,69 @@
 const fetch = require("node-fetch");
 const { parseStringPromise } = require("xml2js");
 const { XmlEntities } = require("html-entities");
+const EventEmitter = require("events");
 
 const entities = new XmlEntities();
 
-module.exports = class VLCClient {
+module.exports = class VLCClient extends EventEmitter {
     constructor(baseURL, password){
+        super();
+
         let authDigest = Buffer.from(":" + password).toString("base64");
 
         this._baseURL = baseURL || "http://localhost:8080";
         this._headers = {
             "Authorization": "Basic " + authDigest
         };
+
+        this._started = false;
+        this._timer = null;
+        this._previousFilename = null;
+    }
+
+    start(){
+        if (this._started)
+            return false;
+
+        const callback = () => {
+            this.getStatus()
+                .then(status => {
+                    var filename = null;
+
+                    if (status && status.information.meta.filename) {
+                        filename = status.information.meta.filename;
+                    }
+
+                    if (this._previousFilename !== filename){
+                        this.emit("song-changed", status);
+                    }
+
+                    this._previousFilename = filename;
+
+                    if (this._started)
+                        this._timer = setTimeout(callback, 10000);
+                });
+        }
+
+        this._started = true;
+
+        callback();
+
+        return true;
+    }
+
+    stop(){
+        if (!this._started)
+            return false;
+
+        if (this._timer) {
+            clearTimeout(this._timer);
+            this._timer = null;
+        }
+
+        this._started = false;
+
+        return true;
     }
 
     getStatus(){

--- a/package-lock.json
+++ b/package-lock.json
@@ -167,6 +167,23 @@
         "handlebars": "^4.7.6"
       }
     },
+    "express-ws": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/express-ws/-/express-ws-3.0.0.tgz",
+      "integrity": "sha1-fdqvO3x1iGXAmZBZiZEbYjRHfb0=",
+      "requires": {
+        "ws": "^2.0.0"
+      }
+    },
+    "express-ws-event-bus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/express-ws-event-bus/-/express-ws-event-bus-1.0.0.tgz",
+      "integrity": "sha512-7WGFKlmeLKSe36sOOqtrNewRkrbmrRQGcVjcpu5Ql4q/RsPO2L4pg1t4F4Wy+AJUXVZrZGgIALfXwU/SFQ2RWA==",
+      "requires": {
+        "express": "^4.16.2",
+        "express-ws": "^3.0.0"
+      }
+    },
     "finalhandler": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
@@ -485,6 +502,11 @@
       "integrity": "sha512-OApPSuJcxcnewwjSGGfWOjx3oix5XpmrK9Z2j0fTRlHGoZ49IU6kExfZTM0++fCArOOCet+vIfWwFHbvWqwp6g==",
       "optional": true
     },
+    "ultron": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
+      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
+    },
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -509,6 +531,22 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "ws": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-2.3.1.tgz",
+      "integrity": "sha1-a5Sz5EfLajY/eF6vlK9jWejoHIA=",
+      "requires": {
+        "safe-buffer": "~5.0.1",
+        "ultron": "~1.1.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+          "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c="
+        }
+      }
     },
     "xml2js": {
       "version": "0.4.23",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "express": "^4.17.1",
     "express-handlebars": "^5.1.0",
+    "express-ws-event-bus": "^1.0.0",
     "html-entities": "^1.3.1",
     "node-fetch": "^2.6.1",
     "xml2js": "^0.4.23"

--- a/server.js
+++ b/server.js
@@ -5,6 +5,9 @@ const url = require ("url");
 const app = express();
 const port = process.env["PORT"] || 3000;
 
+const websocketBus = require("express-ws-event-bus");
+const websocketRouter = websocketBus(app, "/lib/websocket-bus")
+
 const VLC = require("./lib/vlc");
 const vlcClient = new VLC(null, process.env["VLC_PASS"]);
 
@@ -40,11 +43,16 @@ app.get("/artwork", (req, res) => {
         });
 });
 
+
+websocketRouter("/ws").then(socket => {
 vlcClient.on("song-changed", (status) => {
+        socket.send("song-changed", status);
+
     if (!status || !status.information.meta.filename)
         console.log("The beats have stopped.");
     else
         console.log(`Now Playing: "${status.information.meta.title}"`)
+});
 });
 
 vlcClient.start();

--- a/server.js
+++ b/server.js
@@ -40,6 +40,15 @@ app.get("/artwork", (req, res) => {
         });
 });
 
+vlcClient.on("song-changed", (status) => {
+    if (!status || !status.information.meta.filename)
+        console.log("The beats have stopped.");
+    else
+        console.log(`Now Playing: "${status.information.meta.title}"`)
+});
+
+vlcClient.start();
+
 app.listen(port, () =>{
     console.log(`Now Playing server listening at http://localhost:${port}`)
 });

--- a/views/now-playing.handlebars
+++ b/views/now-playing.handlebars
@@ -1,18 +1,31 @@
 <div style="color: white; text-shadow: -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000;">
-    <img src="/artwork" style="max-width: 75px; max-height: 75px; float: right;">
-    <div style="text-align: center; width: 100%; font-size: 2rem; font-weight: bold;">
+    <img id="artwork" src="/artwork" style="max-width: 75px; max-height: 75px; float: right;">
+    <div id="song-title" style="text-align: center; width: 100%; font-size: 2rem; font-weight: bold;">
         {{ vlcStatus.information.meta.title}}
-    <div>
-    <div style="text-align: center; width: 100%; font-size: 1rem; font-weight: lighter;">
+    </div>
+    <div id="album" style="text-align: center; width: 100%; font-size: 1rem; font-weight: lighter;">
         {{ vlcStatus.information.meta.album}}
     </div>
-    <div style="text-align: center; width: 100%; font-size: 1.5rem;">
+    <div id="artist" style="text-align: center; width: 100%; font-size: 1.5rem;">
         {{ vlcStatus.information.meta.artist }}
     </div>
 </div>
+<script src="lib/websocket-bus/websocket-client.js" type="text/javascript"></script>
 <script type="text/javascript">
-// Refresh the page every 10 seconds
-setTimeout(function () {
-    window.location.reload();
-}, 10000)
+    function replaceContents(id, text){
+        textNode = document.createTextNode(text);
+
+        outer = document.getElementById(id);
+        outer.innerHTML = "";
+        outer.appendChild(textNode);
+    }
+
+    getWebsocket("/ws").then(socket => {
+        socket.on("song-changed", status => {
+            replaceContents("song-title", status.information.meta.title);
+            replaceContents("album", status.information.meta.album);
+            replaceContents("artist", status.information.meta.artist);
+            document.getElementById("artwork").src = "/artwork?" + new Date().getTime();
+        });
+    });
 </script>


### PR DESCRIPTION
Working toward having a Websocket connection at the front-end that the server can use to push change events to.

By itself, this patch actually gets pretty close to the basic needs of a Twitch bot to announce song changes. On a whim, this PR could head in that direction.

Fixes #3 